### PR TITLE
Expose PCA threshold in UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,12 @@ debug_mode = st.checkbox("Debug mode", value=False)
 extract_bib = st.checkbox("Extract bib number (very slow)", value=False)
 visualize_embeddings = st.checkbox("Visualize embeddings", value=False)
 min_face_size = st.number_input("Minimum face pixel height", value=5, min_value=1, max_value=100000)
+auto_pca_threshold_percent = st.slider(
+    "PCA variance threshold (%)",
+    min_value=1,
+    max_value=100,
+    value=70,
+)
 reducer_choice = st.selectbox("Dimensionality reduction", ["None", "pca", "tsne"], index=1)
 
 uploaded_files = st.file_uploader("Upload runner images", type=["jpg", "jpeg", "png"], accept_multiple_files=True)
@@ -51,6 +57,7 @@ if st.button("Process") and uploaded_files:
         reduce_method=None if reducer_choice == "None" else reducer_choice,
         n_components="auto",
         min_face_size=min_face_size,
+        auto_pca_threshold=auto_pca_threshold_percent / 100,
     )
 
     for cluster_id, info in summary.items():

--- a/app.py
+++ b/app.py
@@ -4,7 +4,6 @@ app for runner face clustering using Streamlit.
 
 import shutil
 from io import BufferedReader
-from itertools import chain
 from pathlib import Path
 
 import streamlit as st
@@ -78,7 +77,11 @@ if st.button("Process") and uploaded_files:
         TEXT = f"person#{cluster_id}-bib#{info['bib']}" if info["bib"] else f"person#{cluster_id}"
         folder = output_dir / (TEXT)
         with st.expander(TEXT, expanded=False):
-            image_files = chain.from_iterable(folder.glob(ext) for ext in image_extensions)
+            image_files = [
+                p
+                for p in folder.iterdir()
+                if p.suffix.lower() in {".jpg", ".jpeg", ".png"}
+            ]
             for image_file in image_files:
                 st.image(str(image_file))
 

--- a/app.py
+++ b/app.py
@@ -9,8 +9,6 @@ from pathlib import Path
 import streamlit as st
 
 import main
-
-image_extensions = ["*.jpg", "*.jpeg", "*.png"]
 st.title("Runner Face Clustering UI")
 
 debug_mode = st.checkbox("Debug mode", value=False)
@@ -42,7 +40,7 @@ uploaded_files = st.file_uploader("Upload runner images", type=["jpg", "jpeg", "
 
 if st.button("Process") and uploaded_files:
     images_dir = Path("images")
-    output_dir = Path("output")
+    output_dir = main.output_dir
     # Remove everything in images/ to prevent old data contamination
     if images_dir.exists():
         shutil.rmtree(images_dir)
@@ -75,18 +73,18 @@ if st.button("Process") and uploaded_files:
 
     for cluster_id, info in summary.items():
         TEXT = f"person#{cluster_id}-bib#{info['bib']}" if info["bib"] else f"person#{cluster_id}"
-        folder = output_dir / (TEXT)
+        folder = output_dir / TEXT
         with st.expander(TEXT, expanded=False):
             image_files = [
                 p
                 for p in folder.iterdir()
-                if p.suffix.lower() in {".jpg", ".jpeg", ".png"}
+                if p.is_file() and p.suffix.lower() in {".jpg", ".jpeg", ".png"}
             ]
             for image_file in image_files:
                 st.image(str(image_file))
 
     if output_dir.exists():
-        archive_path = shutil.make_archive("output", "zip", "output")
+        archive_path = shutil.make_archive("output", "zip", str(output_dir))
         archive_file: BufferedReader = open(archive_path, "rb")  # pylint: disable=consider-using-with
         with archive_file:
             st.download_button(

--- a/app.py
+++ b/app.py
@@ -18,13 +18,26 @@ debug_mode = st.checkbox("Debug mode", value=False)
 extract_bib = st.checkbox("Extract bib number (very slow)", value=False)
 visualize_embeddings = st.checkbox("Visualize embeddings", value=False)
 min_face_size = st.number_input("Minimum face pixel height", value=5, min_value=1, max_value=100000)
-auto_pca_threshold_percent = st.slider(
-    "PCA variance threshold (%)",
-    min_value=1,
-    max_value=100,
-    value=70,
-)
+
 reducer_choice = st.selectbox("Dimensionality reduction", ["None", "pca", "tsne"], index=1)
+
+AUTO_PCA_THRESHOLD_PERCENT = 70
+N_COMPONENTS = "auto"
+if reducer_choice == "pca":
+    AUTO_PCA_THRESHOLD_PERCENT = st.slider(
+        "PCA variance threshold (%)",
+        min_value=1,
+        max_value=100,
+        value=70,
+    )
+elif reducer_choice == "tsne":
+    N_COMPONENTS = st.number_input(
+        "t-SNE components",
+        min_value=2,
+        max_value=50,
+        value=2,
+        step=1,
+    )
 
 uploaded_files = st.file_uploader("Upload runner images", type=["jpg", "jpeg", "png"], accept_multiple_files=True)
 
@@ -55,9 +68,9 @@ if st.button("Process") and uploaded_files:
         extract_bib=extract_bib,
         visualize=visualize_embeddings,
         reduce_method=None if reducer_choice == "None" else reducer_choice,
-        n_components="auto",
+        n_components=N_COMPONENTS,
         min_face_size=min_face_size,
-        auto_pca_threshold=auto_pca_threshold_percent / 100,
+        auto_pca_threshold=AUTO_PCA_THRESHOLD_PERCENT / 100,
     )
 
     for cluster_id, info in summary.items():

--- a/app.py
+++ b/app.py
@@ -78,7 +78,11 @@ if st.button("Process") and uploaded_files:
         TEXT = f"person#{cluster_id}-bib#{info['bib']}" if info["bib"] else f"person#{cluster_id}"
         folder = output_dir / (TEXT)
         with st.expander(TEXT, expanded=False):
-            image_files = chain.from_iterable(folder.glob(ext) for ext in image_extensions)
+            image_files = [
+                p
+                for p in folder.iterdir()
+                if p.suffix.lower() in {".jpg", ".jpeg", ".png"}
+            ]
             for image_file in image_files:
                 st.image(str(image_file))
 

--- a/app.py
+++ b/app.py
@@ -43,6 +43,7 @@ uploaded_files = st.file_uploader("Upload runner images", type=["jpg", "jpeg", "
 
 if st.button("Process") and uploaded_files:
     images_dir = Path("images")
+    output_dir = Path("output")
     # Remove everything in images/ to prevent old data contamination
     if images_dir.exists():
         shutil.rmtree(images_dir)
@@ -75,13 +76,13 @@ if st.button("Process") and uploaded_files:
 
     for cluster_id, info in summary.items():
         TEXT = f"person#{cluster_id}-bib#{info['bib']}" if info["bib"] else f"person#{cluster_id}"
-        folder = Path("output") / (TEXT)
+        folder = output_dir / (TEXT)
         with st.expander(TEXT, expanded=False):
             image_files = chain.from_iterable(folder.glob(ext) for ext in image_extensions)
             for image_file in image_files:
                 st.image(str(image_file))
 
-    if Path("output").exists():
+    if output_dir.exists():
         archive_path = shutil.make_archive("output", "zip", "output")
         archive_file: BufferedReader = open(archive_path, "rb")  # pylint: disable=consider-using-with
         with archive_file:

--- a/cluster_faces.py
+++ b/cluster_faces.py
@@ -16,6 +16,7 @@ def cluster_face_embeddings(
     embeddings: Sequence[np.ndarray],
     reduce_method: str | None = None,
     n_components: int | str = 2,
+    auto_pca_threshold: float = 0.7,
 ):
     """Cluster face embeddings using HDBSCAN with optional dimensionality reduction.
 
@@ -27,7 +28,11 @@ def cluster_face_embeddings(
         If provided, reduce the embeddings before clustering using the specified method.
     n_components : int | str, optional
         Number of dimensions for the reducer. If ``"auto"`` with PCA, the number
-        of components explaining at least 90% variance is chosen. Defaults to ``2``.
+        of components explaining at least ``auto_pca_threshold`` variance is
+        chosen. Defaults to ``2``.
+    auto_pca_threshold : float, optional
+        Proportion of variance to explain when automatically selecting PCA
+        components. Defaults to ``0.7`` (70%%).
 
     Returns
     -------
@@ -49,7 +54,10 @@ def cluster_face_embeddings(
     if reduce_method:
         if reduce_method == "pca":
             if n_components == "auto":
-                n_components = _auto_pca_components(stacked_embed)
+                n_components = _auto_pca_components(
+                    stacked_embed,
+                    threshold=auto_pca_threshold,
+                )
             reducer = PCA(n_components=int(n_components))
         elif reduce_method == "tsne":
             n_components = 2 if n_components == "auto" else n_components

--- a/main.py
+++ b/main.py
@@ -68,6 +68,7 @@ def process_images(
     reduce_method: str | None = None,
     n_components: int | str = 2,
     min_face_size: int = 5,
+    auto_pca_threshold: float = 0.7,
 ):
     """Process a list of image paths to detect runners, extract faces, and cluster them.
 
@@ -88,9 +89,13 @@ def process_images(
         Allowed values are ``"pca"`` and ``"tsne"``.
     n_components : int | str, optional
         Number of dimensions for the reducer. If ``"auto"`` with PCA, choose the
-        number of components explaining at least 90% variance. Defaults to ``2``.
+        number of components explaining at least ``auto_pca_threshold`` variance.
+        Defaults to ``2``.
     min_face_size : int, optional
         Minimum width/height in pixels for detected faces. Smaller faces are skipped.
+    auto_pca_threshold : float, optional
+        Proportion of variance to explain when automatically selecting PCA components.
+        Defaults to ``0.7`` (70%%).
 
     Returns
     -------
@@ -135,6 +140,7 @@ def process_images(
             [s["embedding"] for s in samples],
             reduce_method=reduce_method,
             n_components=n_components,
+            auto_pca_threshold=auto_pca_threshold,
         )
     else:
         labels = []
@@ -144,6 +150,7 @@ def process_images(
             [s["embedding"] for s in samples],
             method=reduce_method or "pca",
             n_components=n_components,
+            auto_pca_threshold=auto_pca_threshold,
         )
         plot_embeddings(reduced, labels=labels, out_path="output/embeddings.png")
 
@@ -229,6 +236,7 @@ def main(
     reduce_method: str | None = None,
     n_components: int | str = 2,
     min_face_size: int = 5,
+    auto_pca_threshold: float = 0.7,
 ):
     """Main function to process images.
 
@@ -243,6 +251,7 @@ def main(
         reduce_method=reduce_method,
         n_components=n_components,
         min_face_size=min_face_size,
+        auto_pca_threshold=auto_pca_threshold,
     )
 
 
@@ -279,6 +288,12 @@ if __name__ == "__main__":  # pragma: no cover - CLI entry point
         default=5,
         help="Minimum width/height in pixels for detected faces",
     )
+    parser.add_argument(
+        "--auto-pca-threshold",
+        type=float,
+        default=0.7,
+        help="Variance proportion for automatic PCA component selection",
+    )
 
     args = parser.parse_args()
     n_components_arg: int | str = "auto" if args.n_components == "auto" else int(args.n_components)
@@ -289,4 +304,5 @@ if __name__ == "__main__":  # pragma: no cover - CLI entry point
         reduce_method=args.reduce_method,
         n_components=n_components_arg,
         min_face_size=args.min_face_size,
+        auto_pca_threshold=args.auto_pca_threshold,
     )

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import glob
 import json
 import os
 import shutil
+from pathlib import Path
 
 import cv2
 import numpy as np
@@ -21,9 +22,13 @@ from detect_runners import detect_persons
 from face_embeddings import extract_face_embeddings
 from visualize_embeddings import plot_embeddings, reduce_embeddings
 
-if os.path.exists("output"):
-    shutil.rmtree("output")
-os.makedirs("output")
+output_dir = Path("output")
+output_dir.mkdir(exist_ok=True)
+for item in output_dir.iterdir():
+    if item.is_dir():
+        shutil.rmtree(item)
+    else:
+        item.unlink()
 
 DEBUG = True
 
@@ -104,6 +109,12 @@ def process_images(
     """
     samples = []
     total_images = len(image_paths)
+
+    for item_ in output_dir.iterdir():
+        if item_.is_dir():
+            shutil.rmtree(item_)
+        else:
+            item_.unlink()
 
     for idx, img_path in enumerate(image_paths, start=1):
         image = cv2.imread(img_path)

--- a/main.py
+++ b/main.py
@@ -36,9 +36,9 @@ DEBUG = True
 def apply_clahe(image):
     """Apply CLAHE to enhance contrast in the image."""
     lab = cv2.cvtColor(image, cv2.COLOR_BGR2LAB)
-    l, a, b = cv2.split(lab)
+    l_channel, a, b = cv2.split(lab)
     clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
-    cl = clahe.apply(l)
+    cl = clahe.apply(l_channel)
     merged = cv2.merge((cl, a, b))
     return cv2.cvtColor(merged, cv2.COLOR_LAB2BGR)
 

--- a/main.py
+++ b/main.py
@@ -13,7 +13,6 @@ import shutil
 from pathlib import Path
 
 import cv2
-import numpy as np
 
 from cluster_faces import cluster_face_embeddings
 from crop_bodies import crop_person
@@ -31,29 +30,6 @@ for item in output_dir.iterdir():
         item.unlink()
 
 DEBUG = True
-
-
-def apply_clahe(image):
-    """Apply CLAHE to enhance contrast in the image."""
-    lab = cv2.cvtColor(image, cv2.COLOR_BGR2LAB)
-    l_channel, a, b = cv2.split(lab)
-    clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
-    cl = clahe.apply(l_channel)
-    merged = cv2.merge((cl, a, b))
-    return cv2.cvtColor(merged, cv2.COLOR_LAB2BGR)
-
-
-def sharpen(image):
-    """Apply sharpening filter to the image."""
-    kernel = np.array([[-1, -1, -1], [-1, 9, -1], [-1, -1, -1]])
-    return cv2.filter2D(image, -1, kernel)
-
-
-def preprocess_image(image):
-    """Preprocess the image for better OCR and face detection."""
-    image = apply_clahe(image)
-    image = sharpen(image)
-    return image
 
 
 def preprocess_for_ocr(image):
@@ -118,7 +94,6 @@ def process_images(
 
     for idx, img_path in enumerate(image_paths, start=1):
         image = cv2.imread(img_path)
-        # image = preprocess_image(image)
         persons = detect_persons(image)
 
         for box in persons:


### PR DESCRIPTION
## Summary
- let `_auto_pca_components` docstring mention default threshold
- allow `reduce_embeddings` & `cluster_face_embeddings` to accept `auto_pca_threshold`
- thread the new parameter through `process_images` and `main`
- add CLI/UI option to adjust PCA variance threshold
- disable duplicate-code lint in `visualize_embeddings`

## Testing
- `pre-commit run --files app.py cluster_faces.py main.py visualize_embeddings.py`

------
https://chatgpt.com/codex/tasks/task_e_68699463a3b88324a84135ac726a88fe