### PR TITLE
Fix UI image display for uppercase extensions

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,7 +78,11 @@ if st.button("Process") and uploaded_files:
         TEXT = f"person#{cluster_id}-bib#{info['bib']}" if info["bib"] else f"person#{cluster_id}"
         folder = output_dir / (TEXT)
         with st.expander(TEXT, expanded=False):
-            image_files = chain.from_iterable(folder.glob(ext) for ext in image_extensions)
+            image_files = [
+                p
+                for p in folder.iterdir()
+                if p.suffix.lower() in {".jpg", ".jpeg", ".png"}
+            ]
             for image_file in image_files:
                 st.image(str(image_file))
 


### PR DESCRIPTION
## Summary
- handle uppercase image extensions when showing cluster results

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68699e9138c08324bad677b2c954a989