### PR TITLE
Add clear button for uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import streamlit as st
 
 import main
+
 st.title("Runner Face Clustering UI")
 
 debug_mode = st.checkbox("Debug mode", value=False)
@@ -36,7 +37,16 @@ elif reducer_choice == "tsne":
         step=1,
     )
 
-uploaded_files = st.file_uploader("Upload runner images", type=["jpg", "jpeg", "png"], accept_multiple_files=True)
+uploaded_files = st.file_uploader(
+    "Upload runner images",
+    type=["jpg", "jpeg", "png"],
+    accept_multiple_files=True,
+    key="uploaded_images",
+)
+
+if st.button("Clear All"):
+    st.session_state["uploaded_images"] = []
+    uploaded_files = []
 
 if st.button("Process") and uploaded_files:
     images_dir = Path("images")
@@ -75,11 +85,7 @@ if st.button("Process") and uploaded_files:
         TEXT = f"person#{cluster_id}-bib#{info['bib']}" if info["bib"] else f"person#{cluster_id}"
         folder = output_dir / TEXT
         with st.expander(TEXT, expanded=False):
-            image_files = [
-                p
-                for p in folder.iterdir()
-                if p.is_file() and p.suffix.lower() in {".jpg", ".jpeg", ".png"}
-            ]
+            image_files = [p for p in folder.iterdir() if p.is_file() and p.suffix.lower() in {".jpg", ".jpeg", ".png"}]
             for image_file in image_files:
                 st.image(str(image_file))
 

--- a/app.py
+++ b/app.py
@@ -37,16 +37,18 @@ elif reducer_choice == "tsne":
         step=1,
     )
 
+if "upload_key" not in st.session_state:
+    st.session_state["upload_key"] = 0
+
+if st.button("Clear All"):
+    st.session_state["upload_key"] += 1
+
 uploaded_files = st.file_uploader(
     "Upload runner images",
     type=["jpg", "jpeg", "png"],
     accept_multiple_files=True,
-    key="uploaded_images",
+    key=f"uploaded_images_{st.session_state['upload_key']}",
 )
-
-if st.button("Clear All"):
-    st.session_state["uploaded_images"] = []
-    uploaded_files = []
 
 if st.button("Process") and uploaded_files:
     images_dir = Path("images")


### PR DESCRIPTION
## Summary
- add a `Clear All` button to reset uploaded runner images in the Streamlit UI

## Testing
- `pre-commit run --files app.py`

------
https://chatgpt.com/codex/tasks/task_e_6869bb101e888324ac1658802890a32d